### PR TITLE
only save log if there is a change to report

### DIFF
--- a/lib/bulky/updater.rb
+++ b/lib/bulky/updater.rb
@@ -29,7 +29,7 @@ module Bulky
       log.error_backtrace = e.backtrace.join("\n")
       raise e
     ensure
-      log.save!
+      log.save! if log.updatable_changes.present?
     end
   end
 end


### PR DESCRIPTION
essentially we don't want to save a log if there are no changes to be made.  this happens when the same changes is applied to the model more than once.
